### PR TITLE
Add aarch64 compatibility

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,6 +14,24 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1700786208,
@@ -28,9 +46,28 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/src/nixos-module.nix
+++ b/src/nixos-module.nix
@@ -5,7 +5,7 @@ self:
 let
   cfg = config.services.snap;
 
-  snap = self.packages.x86_64-linux.default.override {
+  snap = self.packages.${pkgs.system}.default.override {
     snapConfineWrapper = "${config.security.wrapperDir}/snap-confine-stage-1";
   };
 

--- a/src/package.nix
+++ b/src/package.nix
@@ -191,6 +191,7 @@ in stdenv.mkDerivation {
         lib.makeBinPath (with pkgs; [
           # Snapd calls
           util-linux.mount
+          shadow
           squashfsTools
           systemd
           openssh

--- a/src/test.nix
+++ b/src/test.nix
@@ -3,7 +3,7 @@
 let
   nixos-lib = import "${pkgs.path}/nixos/lib" { };
 
-  snap = self.packages.x86_64-linux.default;
+  snap = self.packages.${pkgs.system}.default;
 
   # Download tested snaps with a fixed-output derivation because the test runner
   # normally doesn't have internet access


### PR DESCRIPTION
This adds aarch64 compatiblity. 
Didn't need to change much besides presenting the package as aarch64.

Another addition is the inclusion of `shadow`, in my quest to get the [oracle-cloud-agent](https://snapcraft.io/oracle-cloud-agent) working I noticed that it refuses to install if `groupadd` is not in the `PATH`. Can remove if this is OOS for this PR.
thanks for creating this!
